### PR TITLE
feat: Kith WebSocket voice streaming for Kaori Live

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ NEXT_PUBLIC_BUNNY_CDN_HOSTNAME=your-cdn-hostname.b-cdn.net
 
 # Stripe
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your-stripe-key
+
+# Kith Voice Service (Kaori TTS WebSocket)
+NEXT_PUBLIC_KITH_VOICE_WS_URL=ws://localhost:3040/ws

--- a/lib/apiMessages.js
+++ b/lib/apiMessages.js
@@ -70,12 +70,12 @@ export async function startConversation(targetUserId, token) {
  * @param {string} token - JWT auth token
  * @returns {Promise<Object>} Created message object
  */
-export async function sendMessage(conversationId, content, token) {
+export async function sendMessage(conversationId, content, token, extraHeaders) {
   const response = await axios.post(
     `${API_BASE_URL}/dm/conversations/${conversationId}/messages`,
     { content },
     {
-      headers: { 'x-auth-token': token },
+      headers: { 'x-auth-token': token, ...extraHeaders },
     },
   );
   return response.data;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.18",
         "@mui/material": "^5.15.18",
-        "@pixiv/three-vrm": "^3.5.1",
+        "@pixiv/three-vrm": "^3.5.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.6",
@@ -69,7 +69,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -489,7 +488,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -500,7 +498,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -510,14 +507,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -989,7 +984,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1003,7 +997,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1013,7 +1006,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1032,139 +1024,139 @@
       }
     },
     "node_modules/@pixiv/three-vrm": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm/-/three-vrm-3.5.1.tgz",
-      "integrity": "sha512-B2u0uCi2SHO83ycrgOJVDbtgLtQpgWbDdHRQ4SCeu+CZ0Dh1If5RDM2oUIbMA0j/6o93T385iSj4FHn/7ZvdCg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm/-/three-vrm-3.5.2.tgz",
+      "integrity": "sha512-YC3T8WZvb18n1uzYS60I9WCc2kOJxWZ/Q0RfklFAg0nD3Dz/kvvEoCYfZj5idnJqOtbLUXZGXZF1KCXKUB2qHg==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/three-vrm-core": "3.5.1",
-        "@pixiv/three-vrm-materials-hdr-emissive-multiplier": "3.5.1",
-        "@pixiv/three-vrm-materials-mtoon": "3.5.1",
-        "@pixiv/three-vrm-materials-v0compat": "3.5.1",
-        "@pixiv/three-vrm-node-constraint": "3.5.1",
-        "@pixiv/three-vrm-springbone": "3.5.1"
+        "@pixiv/three-vrm-core": "3.5.2",
+        "@pixiv/three-vrm-materials-hdr-emissive-multiplier": "3.5.2",
+        "@pixiv/three-vrm-materials-mtoon": "3.5.2",
+        "@pixiv/three-vrm-materials-v0compat": "3.5.2",
+        "@pixiv/three-vrm-node-constraint": "3.5.2",
+        "@pixiv/three-vrm-springbone": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-3.5.1.tgz",
-      "integrity": "sha512-uKT9wBXHzE6U3sABdKwNnLOj28akQPGF8+P1EGdEb/j3Fcmn2qmFwUq7rbKwKJP8WGAHp++N1LJn3r+xVjyLBA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-core/-/three-vrm-core-3.5.2.tgz",
+      "integrity": "sha512-QFpkCvsD5VMApNyIqFEw1lxSKFCM5X8+715FsfsAOx5mLh2LP0E0pDmqpDjfau/kAkDpWquGwzzHmXdAYjc8mQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "3.5.1",
-        "@pixiv/types-vrmc-vrm-1.0": "3.5.1"
+        "@pixiv/types-vrm-0.0": "3.5.2",
+        "@pixiv/types-vrmc-vrm-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-materials-hdr-emissive-multiplier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-hdr-emissive-multiplier/-/three-vrm-materials-hdr-emissive-multiplier-3.5.1.tgz",
-      "integrity": "sha512-BlKRo9Oa8fdVakXGptjTfBG+JpTlDWKEipBF+yQ2v9Vo13rIJXcNCv3HgpbxFDJh+BssKC5WH0Tuw0BE2UPLwg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-hdr-emissive-multiplier/-/three-vrm-materials-hdr-emissive-multiplier-3.5.2.tgz",
+      "integrity": "sha512-XJk6l/kexWeYpZmQu0h6VBXPsx4IV2uCN/9EPSJV8usspmP8CcMOsWx/5ESW4DKvGFufbiFZ5J6SGECJOTXTYg==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.5.1"
+        "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-materials-mtoon": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-mtoon/-/three-vrm-materials-mtoon-3.5.1.tgz",
-      "integrity": "sha512-6zrSDsdiQRtzU0/ZUbRuLnjaqfhFmivQ2OBwpJgtjXuHjCZVcsR8GmiDk+0/6OFlaWymux/CpPidLKN9DWr0Mw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-mtoon/-/three-vrm-materials-mtoon-3.5.2.tgz",
+      "integrity": "sha512-P0oobZJ+JrMae7jdGgHqQqcoHpp3WYXq5blyCMybfsgxh9KtDzJ2NpBXf57LQlkN0cD6iT0R299tAqfH/1Uqcg==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "3.5.1",
-        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.1"
+        "@pixiv/types-vrm-0.0": "3.5.2",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-materials-v0compat": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-v0compat/-/three-vrm-materials-v0compat-3.5.1.tgz",
-      "integrity": "sha512-pVzEQDDaKIwJ0DBtHl+Q9wr2FtkxauEkmsw9jt1ZoSk7QxI1vkhCAbWUXAS6XT5ttZ4izbhfNd9Brn4f5Kigxg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-materials-v0compat/-/three-vrm-materials-v0compat-3.5.2.tgz",
+      "integrity": "sha512-KuAq0ewDGqDKP8lmLAFrhpwRhYnUhnck6HqjO90XJM1b6HgoqyZK2CNOfTsgJQMJgp7sXF6J0EhjCkBiXTNvGA==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "3.5.1",
-        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.1"
+        "@pixiv/types-vrm-0.0": "3.5.2",
+        "@pixiv/types-vrmc-materials-mtoon-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-node-constraint": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-node-constraint/-/three-vrm-node-constraint-3.5.1.tgz",
-      "integrity": "sha512-Bywh9IpfEUbQxFijiksNZUOaAodLhgvlD5nZjsNwx6uOxYPfSYYJkxjLA3+wxwt6rT7bS41FEUBMBYAmdsXHkg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-node-constraint/-/three-vrm-node-constraint-3.5.2.tgz",
+      "integrity": "sha512-jUBL6XkgTKhf/YgkDILHYAjOlN4n1Oz2dSSSvIfbJ0RVDah9jACm2775ZTult9ADgWmyvBsJQUr5u8JWOMLOKg==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrmc-node-constraint-1.0": "3.5.1"
+        "@pixiv/types-vrmc-node-constraint-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/three-vrm-springbone": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-springbone/-/three-vrm-springbone-3.5.1.tgz",
-      "integrity": "sha512-ylsukk+2o9t06vMEiOqE1443FDQYpozbov375SE8phgCDqfmPe9YEEvAX3md0cCCqOfqMWuXdxzU8avWXXynTw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/three-vrm-springbone/-/three-vrm-springbone-3.5.2.tgz",
+      "integrity": "sha512-+V3ok2W93f7U4wTcclgZxwz3hKe78DjStl1lCBsORKTo21tLMHyeHoNDQCJ8i1bvjLrr4QLfGYH/oBbVNPxvWQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixiv/types-vrm-0.0": "3.5.1",
-        "@pixiv/types-vrmc-springbone-1.0": "3.5.1",
-        "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.5.1"
+        "@pixiv/types-vrm-0.0": "3.5.2",
+        "@pixiv/types-vrmc-springbone-1.0": "3.5.2",
+        "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.5.2"
       },
       "peerDependencies": {
         "three": ">=0.137"
       }
     },
     "node_modules/@pixiv/types-vrm-0.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-3.5.1.tgz",
-      "integrity": "sha512-97XgNpLw0v6YPVqzTALIjPftyOZnkK8Rd4QWwlI5RVo96DASSTrPpdMw1HAwwcDEGHj35ru9Cxar97eUltkJug==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrm-0.0/-/types-vrm-0.0-3.5.2.tgz",
+      "integrity": "sha512-H+aiDQqezc1plVJFyvxK4/gfFtpKlK9WghumHGm+dnsRoROLmUZw6sQoHmpd9UoXI2hu1UHiIyyJLHP/MMaWhQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0/-/types-vrmc-materials-hdr-emissive-multiplier-1.0-3.5.1.tgz",
-      "integrity": "sha512-/kZpjn3yDIH5+BlZz6VkCd7694Pz9kFTc/ImfTKQ/MNfXtmLU7zlhVZ55U/E/9kkSyzJ6ocmLgO9FnMRqZ2YBQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0/-/types-vrmc-materials-hdr-emissive-multiplier-1.0-3.5.2.tgz",
+      "integrity": "sha512-dv8oJ8uFRsGqLUtV75Dovmg3lbTbu5oi5s+P/5+oPy7LCs/JsJtSDXCycDwQBYtrie797VMHp4b7G8TvGCP+gQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-materials-mtoon-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-mtoon-1.0/-/types-vrmc-materials-mtoon-1.0-3.5.1.tgz",
-      "integrity": "sha512-8IfN65S4qB+8vNMcsJHcjUAlSalR+T+QY5QZY3JU33/AnLQLJtnMzaRIAbwZyhrzOiIfK0b8eJnjHBYxV2Bteg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-materials-mtoon-1.0/-/types-vrmc-materials-mtoon-1.0-3.5.2.tgz",
+      "integrity": "sha512-dXC9vphdKDKQNpPpj61l+nveQK/soYFpfFqr74hKo/7BaYm5B6nZ6uImQYPCD7U2WICUF91lBoRYKD9ONTPHmQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-node-constraint-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-node-constraint-1.0/-/types-vrmc-node-constraint-1.0-3.5.1.tgz",
-      "integrity": "sha512-oeYhK42AhWCkJGiheY0vGHQkU7ayetI8fk93cU4vOAJUSW5Ric+36KtWAVOgp8Ja5o/RS2cu40Biuma6DZ0H7g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-node-constraint-1.0/-/types-vrmc-node-constraint-1.0-3.5.2.tgz",
+      "integrity": "sha512-4swBTE/FgQlpfOPnnFQFD7GF/XiNB883prIr2KOhAqru0VjOyiYDQPIZTwynKtBFCIjUxp9DW4YQzR6ETqhQmw==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-springbone-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-1.0/-/types-vrmc-springbone-1.0-3.5.1.tgz",
-      "integrity": "sha512-3563cYQ5tjdc0g8tj+hP206z/nKR3uGhoFh2t/r6yCOI6q3SPgSIEkHG8mZu1boegRfPj4fPbXbntQFeqJxECw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-1.0/-/types-vrmc-springbone-1.0-3.5.2.tgz",
+      "integrity": "sha512-Au+nszNPbOuaCdaymOQ5jXFknWb5Md7xjCzoP9aPAHeh1uRKHccR1MErtzuRit/9L6mNhW1OneXet9+Ple5GmQ==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-springbone-extended-collider-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-extended-collider-1.0/-/types-vrmc-springbone-extended-collider-1.0-3.5.1.tgz",
-      "integrity": "sha512-Q975/y/3zEKPggYC3E/6uG/RVTt+2k1GpRfR6ngJ9NHM5rzlSab4yDCSx3qePjHpHIJvS9847LK9HPUrG7f3Og==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-springbone-extended-collider-1.0/-/types-vrmc-springbone-extended-collider-1.0-3.5.2.tgz",
+      "integrity": "sha512-W1CeeAwm6ybiWHrQcqOFOvcO/9LKzLA2fA0wBT30BCwvQFLIwo77mU91N88+TcEeXdH+RxVil/oEdVH7aFZ6nw==",
       "license": "MIT"
     },
     "node_modules/@pixiv/types-vrmc-vrm-1.0": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-3.5.1.tgz",
-      "integrity": "sha512-Ugf8Kv5SSORVf8i+P4i5O2iuMuyzKW6ZRvntWuGXFN6YO7Zx38Vn8zbGKtWTs+zR9dfHWdZixjWcW71Vy4NyVw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@pixiv/types-vrmc-vrm-1.0/-/types-vrmc-vrm-1.0-3.5.2.tgz",
+      "integrity": "sha512-kgvRCJc9J0ruaVIxC5R9x4ZYNpM1bxs7vSMcl4SYPi2+baolHvXQiH0kFaN61+rFleld+sOOjDHtE98egY2dxQ==",
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
@@ -2290,14 +2282,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2329,7 +2319,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2464,7 +2453,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2509,7 +2497,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2594,7 +2581,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2691,7 +2677,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2716,7 +2701,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2904,7 +2888,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2967,7 +2950,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -3083,14 +3065,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -3249,7 +3229,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3266,7 +3245,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3279,7 +3257,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3325,7 +3302,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3451,7 +3427,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3536,7 +3511,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3862,7 +3836,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -3894,7 +3867,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3912,7 +3884,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3925,7 +3896,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3981,7 +3951,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3994,6 +3963,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jquery": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-base64": {
       "version": "3.7.8",
@@ -4104,7 +4080,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4511,6 +4486,30 @@
         "react": "^15.7.0"
       }
     },
+    "node_modules/material-ui-community-icons/node_modules/react-tap-event-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-1.0.0.tgz",
+      "integrity": "sha512-EerIA+llDP1RfqclRCC/VwSZny3cYA9X4+tf6mTiJmICUV1mQIYPSBaZeDa3DErmA9CiqhNltlCJ06U9k9wyhA==",
+      "peer": true,
+      "dependencies": {
+        "fbjs": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0-0"
+      }
+    },
+    "node_modules/material-ui-community-icons/node_modules/react-tap-event-plugin/node_modules/fbjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz",
+      "integrity": "sha512-JRGL7Dyq3p3J/rS1H0GR8OMpJm5x9bc2CyR/u1clWlTZb90wKldS3N4T7Fe4724oNSxtnXES/IYIm4ofteJHwg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "core-js": "^1.0.0",
+        "promise": "^7.0.3",
+        "whatwg-fetch": "^0.9.0"
+      }
+    },
     "node_modules/material-ui-community-icons/node_modules/react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
@@ -4548,6 +4547,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/material-ui-community-icons/node_modules/whatwg-fetch": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+      "integrity": "sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw==",
+      "peer": true
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.0",
@@ -4645,7 +4650,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5076,7 +5080,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5229,7 +5232,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -5448,7 +5450,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5598,7 +5599,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5624,7 +5624,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5634,7 +5633,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5691,7 +5689,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5720,7 +5717,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -5738,7 +5734,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5764,7 +5759,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5790,7 +5784,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5804,7 +5797,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/preact": {
@@ -5910,7 +5902,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6146,7 +6137,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6169,7 +6159,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6321,7 +6310,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6354,7 +6342,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6703,7 +6690,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -6766,7 +6752,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -6813,7 +6798,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6823,7 +6807,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6862,6 +6845,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -6882,7 +6882,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -6892,7 +6891,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -6921,7 +6919,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6938,7 +6935,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6956,7 +6952,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6977,7 +6972,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7024,7 +7018,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.18",
     "@mui/material": "^5.15.18",
-    "@pixiv/three-vrm": "^3.5.1",
+    "@pixiv/three-vrm": "^3.5.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.6",

--- a/pages/kaori-live.js
+++ b/pages/kaori-live.js
@@ -783,7 +783,6 @@ export default function KaoriLivePage() {
     try {
       // Pass x-kith-session header so the backend fires voice through Kith
       const kithSession = kithSessionRef.current;
-      console.log('[kaori-live] sending message, kithSession:', kithSession || '(none)');
       const extraHeaders = kithSession ? { 'x-kith-session': kithSession } : undefined;
       await sendMessage(conversationId, content, token, extraHeaders);
 

--- a/pages/kaori-live.js
+++ b/pages/kaori-live.js
@@ -782,9 +782,9 @@ export default function KaoriLivePage() {
 
     try {
       // Pass x-kith-session header so the backend fires voice through Kith
-      const extraHeaders = kithSessionRef.current
-        ? { 'x-kith-session': kithSessionRef.current }
-        : undefined;
+      const kithSession = kithSessionRef.current;
+      console.log('[kaori-live] sending message, kithSession:', kithSession || '(none)');
+      const extraHeaders = kithSession ? { 'x-kith-session': kithSession } : undefined;
       await sendMessage(conversationId, content, token, extraHeaders);
 
       // Voice arrives via Kith WebSocket (tts_audio_chunk events).
@@ -920,6 +920,9 @@ export default function KaoriLivePage() {
                     msg.senderId === 'me' ||
                     (userId && msg.senderId?.toString() === userId?.toString()) ||
                     `${msg._id || ''}`.startsWith('temp-');
+                  // Hide voice-link messages (legacy MP3 URLs)
+                  if (/Kaori voice:\s*https?:\/\//i.test(msg.content || '')) return null;
+                  if (/https?:\/\/[^\s)]+\.mp3/i.test(msg.content || '')) return null;
                   return (
                     <div
                       key={msg._id || `${msg.createdAt}-${msg.content}`}

--- a/pages/kaori-live.js
+++ b/pages/kaori-live.js
@@ -1,4 +1,4 @@
-import { Mic, MicOff, Loader2, Send, Sparkles } from 'lucide-react';
+import { Loader2, Mic, MicOff, Send, Sparkles, Square } from 'lucide-react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
@@ -15,7 +15,8 @@ import { connectMessagesSocket } from '../lib/socket';
 import styles from '../styles/kaori-live.module.css';
 
 const KAORI_VRM_PATH = '/kaori/kaori_sample.vrm';
-const KAORI_STAGE_BUILD_TAG = 'build-187-force';
+const KAORI_STAGE_BUILD_TAG = 'build-188-kith';
+const KITH_VOICE_WS_URL = process.env.NEXT_PUBLIC_KITH_VOICE_WS_URL || 'ws://localhost:3040/ws';
 
 export default function KaoriLivePage() {
   const { loggedIn, token, userId } = useContext(AuthContext);
@@ -34,15 +35,15 @@ export default function KaoriLivePage() {
   const threeRef = useRef({});
   const recognitionRef = useRef(null);
   const socketRef = useRef(null);
-  const audioRef = useRef(null);
-  const audioAnalyserRef = useRef(null);
-  const audioDataRef = useRef(null);
-  const audioRafRef = useRef(null);
-  const lastPlayedVoiceRef = useRef('');
-  const currentVoiceUrlRef = useRef('');
-  const voicePlayTokenRef = useRef(0);
   const sendLockRef = useRef(false);
   const lastSubmitRef = useRef({ text: '', ts: 0 });
+
+  // Kith voice WebSocket
+  const kithWsRef = useRef(null);
+  const kithSessionRef = useRef('');
+  const audioCtxRef = useRef(null);
+  const audioQueueRef = useRef([]);
+  const audioPlayingRef = useRef(false);
 
   const SpeechRecognition = useMemo(() => {
     if (typeof window === 'undefined') return null;
@@ -100,8 +101,7 @@ export default function KaoriLivePage() {
         return [...prev, message];
       });
 
-      // Do not autoplay voice from socket here; playback is handled in submit flow
-      // to avoid duplicate triggers (socket + polling) and overlapping audio.
+      // Voice playback is handled by Kith WebSocket, not from message content.
     };
 
     socket.on('message:new', onNewMessage);
@@ -111,6 +111,174 @@ export default function KaoriLivePage() {
       socket.off('message:new', onNewMessage);
     };
   }, [token, conversationId, userId]);
+
+  // --- Kith Voice WebSocket ---
+  // Connects to the Kith voice sidecar. Receives streaming TTS audio chunks,
+  // emotion state updates, and turn lifecycle events. Audio chunks are decoded
+  // and queued into Web Audio API for gapless playback.
+  useEffect(() => {
+    if (!conversationId) return;
+
+    let ws;
+    let closed = false;
+
+    const getAudioCtx = () => {
+      if (!audioCtxRef.current) {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (Ctx) audioCtxRef.current = new Ctx();
+      }
+      if (audioCtxRef.current?.state === 'suspended') {
+        audioCtxRef.current.resume().catch(() => {});
+      }
+      return audioCtxRef.current;
+    };
+
+    const drainAudioQueue = async () => {
+      if (audioPlayingRef.current) return;
+      const ctx = getAudioCtx();
+      if (!ctx) return;
+
+      audioPlayingRef.current = true;
+      while (audioQueueRef.current.length > 0) {
+        const b64 = audioQueueRef.current.shift();
+        try {
+          const binary = atob(b64);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+          const audioBuffer = await ctx.decodeAudioData(bytes.buffer.slice(0));
+          await new Promise((resolve) => {
+            const source = ctx.createBufferSource();
+            source.buffer = audioBuffer;
+            source.connect(ctx.destination);
+            source.onended = resolve;
+            source.start();
+          });
+        } catch (err) {
+          console.warn('[kith] audio chunk decode/play error:', err);
+        }
+      }
+      audioPlayingRef.current = false;
+    };
+
+    const connect = () => {
+      if (closed) return;
+      ws = new WebSocket(KITH_VOICE_WS_URL);
+      kithWsRef.current = ws;
+
+      ws.onopen = () => {
+        console.log('[kith] ws connected');
+      };
+
+      ws.onmessage = (e) => {
+        let event;
+        try {
+          event = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+
+        switch (event.type) {
+          case '_ready':
+            kithSessionRef.current = event.sessionId;
+            console.log('[kith] session ready:', event.sessionId);
+            break;
+
+          case 'tts_audio_chunk':
+            audioQueueRef.current.push(event.audioB64);
+            drainAudioQueue();
+            break;
+
+          case 'tts_start':
+            setCharState('speaking');
+            break;
+
+          case 'tts_end':
+            // Wait for queue to drain before going idle
+            if (audioQueueRef.current.length === 0 && !audioPlayingRef.current) {
+              setCharState('idle');
+            }
+            break;
+
+          case 'turn_start':
+            if (event.role === 'assistant') setCharState('speaking');
+            break;
+
+          case 'turn_end':
+            if (event.role === 'assistant') {
+              // Delay idle until audio queue drains
+              const checkIdle = () => {
+                if (audioQueueRef.current.length === 0 && !audioPlayingRef.current) {
+                  setCharState('idle');
+                } else {
+                  setTimeout(checkIdle, 100);
+                }
+              };
+              checkIdle();
+            }
+            break;
+
+          case 'emotion_state':
+            // Apply emotion tint to VRM materials
+            if (threeRef.current.vrm?.scene) {
+              const tints = {
+                excited: 0xffe5a0,
+                calm: 0xa0d8ff,
+                happy: 0xffc0e8,
+                sad: 0x8090cc,
+                neutral: 0xffffff,
+              };
+              const color = tints[event.state] ?? 0xffffff;
+              threeRef.current.vrm.scene.traverse((child) => {
+                if (child.isMesh && child.material?.emissive) {
+                  child.material.emissive.setHex(color);
+                  child.material.emissiveIntensity = event.intensity * 0.3;
+                }
+              });
+            }
+            break;
+
+          case 'barge_in_detected':
+            audioQueueRef.current.length = 0;
+            setCharState('listening');
+            break;
+
+          case 'error':
+            console.error('[kith] error:', event.message);
+            break;
+
+          default:
+            break;
+        }
+      };
+
+      ws.onclose = () => {
+        kithSessionRef.current = '';
+        kithWsRef.current = null;
+        if (!closed) {
+          console.log('[kith] ws closed, reconnecting in 3s...');
+          setTimeout(connect, 3000);
+        }
+      };
+
+      ws.onerror = (err) => {
+        console.error('[kith] ws error:', err);
+      };
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      kithSessionRef.current = '';
+      if (ws) {
+        ws.onclose = null; // prevent reconnect
+        ws.close();
+      }
+      kithWsRef.current = null;
+      audioQueueRef.current.length = 0;
+      audioPlayingRef.current = false;
+    };
+  }, [conversationId]);
 
   useEffect(() => {
     if (loading) return;
@@ -132,7 +300,12 @@ export default function KaoriLivePage() {
       scene.background = new THREE.Color('#07122a');
       scene.fog = new THREE.Fog('#0a1732', 4.5, 12);
 
-      const camera = new THREE.PerspectiveCamera(42, mount.clientWidth / mount.clientHeight, 0.1, 1000);
+      const camera = new THREE.PerspectiveCamera(
+        42,
+        mount.clientWidth / mount.clientHeight,
+        0.1,
+        1000,
+      );
       camera.position.set(0, 1.45, 2.15);
 
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
@@ -155,7 +328,11 @@ export default function KaoriLivePage() {
 
       // Snowy mountain backdrop (Phase A art direction)
       const groundGeo = new THREE.PlaneGeometry(16, 8);
-      const groundMat = new THREE.MeshStandardMaterial({ color: '#a8c5de', roughness: 0.95, metalness: 0.02 });
+      const groundMat = new THREE.MeshStandardMaterial({
+        color: '#a8c5de',
+        roughness: 0.95,
+        metalness: 0.02,
+      });
       const ground = new THREE.Mesh(groundGeo, groundMat);
       ground.rotation.x = -Math.PI / 2;
       ground.position.set(0, -1.45, -1.2);
@@ -193,7 +370,11 @@ export default function KaoriLivePage() {
       scene.add(ring);
 
       const fallbackGeo = new THREE.SphereGeometry(0.55, 32, 32);
-      const fallbackMat = new THREE.MeshStandardMaterial({ color: '#8bb6ff', emissive: '#2a3d77', emissiveIntensity: 0.7 });
+      const fallbackMat = new THREE.MeshStandardMaterial({
+        color: '#8bb6ff',
+        emissive: '#2a3d77',
+        emissiveIntensity: 0.7,
+      });
       const fallbackMesh = new THREE.Mesh(fallbackGeo, fallbackMat);
       fallbackMesh.position.set(0, 0.2, 0);
       scene.add(fallbackMesh);
@@ -398,8 +579,14 @@ export default function KaoriLivePage() {
         smoothedMid = THREE.MathUtils.damp(smoothedMid, bands.mid, 12, dt);
         smoothedHigh = THREE.MathUtils.damp(smoothedHigh, bands.high, 12, dt);
 
-        const mouthTarget = state === 'speaking' ? Math.min(0.62, Math.max(0, smoothedVoice - 0.05) * 0.9) : 0;
-        smoothedMouth = THREE.MathUtils.damp(smoothedMouth, mouthTarget, state === 'speaking' ? 16 : 11, dt);
+        const mouthTarget =
+          state === 'speaking' ? Math.min(0.62, Math.max(0, smoothedVoice - 0.05) * 0.9) : 0;
+        smoothedMouth = THREE.MathUtils.damp(
+          smoothedMouth,
+          mouthTarget,
+          state === 'speaking' ? 16 : 11,
+          dt,
+        );
 
         if (vrm) {
           vrm.update(dt);
@@ -439,20 +626,43 @@ export default function KaoriLivePage() {
             if (spine) spine.rotation.x = 0.06;
           }
 
-          const armTalk = state === 'speaking' ? Math.sin(t * (3.6 + smoothedVoice * 1.8)) * (0.01 + smoothedVoice * 0.016) : 0;
+          const armTalk =
+            state === 'speaking'
+              ? Math.sin(t * (3.6 + smoothedVoice * 1.8)) * (0.01 + smoothedVoice * 0.016)
+              : 0;
           const leftTargetZ = -1.2 + armTalk;
           const rightTargetZ = 1.2 - armTalk;
           const leftTargetY = 0.05;
           const rightTargetY = -0.05;
 
           if (leftUpperArm) {
-            leftUpperArm.rotation.z = THREE.MathUtils.damp(leftUpperArm.rotation.z, leftTargetZ, 7, dt);
-            leftUpperArm.rotation.y = THREE.MathUtils.damp(leftUpperArm.rotation.y, leftTargetY, 7, dt);
+            leftUpperArm.rotation.z = THREE.MathUtils.damp(
+              leftUpperArm.rotation.z,
+              leftTargetZ,
+              7,
+              dt,
+            );
+            leftUpperArm.rotation.y = THREE.MathUtils.damp(
+              leftUpperArm.rotation.y,
+              leftTargetY,
+              7,
+              dt,
+            );
             leftUpperArm.rotation.x = THREE.MathUtils.damp(leftUpperArm.rotation.x, -0.02, 7, dt);
           }
           if (rightUpperArm) {
-            rightUpperArm.rotation.z = THREE.MathUtils.damp(rightUpperArm.rotation.z, rightTargetZ, 7, dt);
-            rightUpperArm.rotation.y = THREE.MathUtils.damp(rightUpperArm.rotation.y, rightTargetY, 7, dt);
+            rightUpperArm.rotation.z = THREE.MathUtils.damp(
+              rightUpperArm.rotation.z,
+              rightTargetZ,
+              7,
+              dt,
+            );
+            rightUpperArm.rotation.y = THREE.MathUtils.damp(
+              rightUpperArm.rotation.y,
+              rightTargetY,
+              7,
+              dt,
+            );
             rightUpperArm.rotation.x = THREE.MathUtils.damp(rightUpperArm.rotation.x, -0.02, 7, dt);
           }
 
@@ -535,173 +745,19 @@ export default function KaoriLivePage() {
     threeRef.current.charState = charState;
   }, [charState]);
 
-  useEffect(() => {
-    return () => {
-      stopCurrentAudio();
-      if (typeof window !== 'undefined' && window.speechSynthesis) {
-        window.speechSynthesis.cancel();
-      }
-    };
-  }, []);
-
-  const extractVoiceUrl = (text = '') => {
-    if (!text) return '';
-
-    const explicit = text.match(/Kaori voice:\s*(https?:\/\/\S+)/i)?.[1];
-    if (explicit) return explicit.trim();
-
-    const kaoriPath = text.match(/https?:\/\/[^\s)]+kaori-voice[^\s)]*\.mp3/i)?.[0];
-    if (kaoriPath) return kaoriPath.trim();
-
-    const anyMp3 = text.match(/https?:\/\/[^\s)]+\.mp3/i)?.[0];
-    return anyMp3?.trim() || '';
+  const stopKithAudio = () => {
+    audioQueueRef.current.length = 0;
+    if (kithWsRef.current?.readyState === WebSocket.OPEN) {
+      kithWsRef.current.send(JSON.stringify({ type: 'barge-in' }));
+    }
+    setCharState('idle');
   };
 
-  const unlockAudioPlayback = async () => {
-    if (typeof window === 'undefined') return;
-    const Ctx = window.AudioContext || window.webkitAudioContext;
-    if (!Ctx) return;
-
-    if (!window.__kaoriAudioCtx) {
-      window.__kaoriAudioCtx = new Ctx();
-    }
-
-    if (window.__kaoriAudioCtx.state === 'suspended') {
-      try {
-        await window.__kaoriAudioCtx.resume();
-      } catch (_err) {
-        // ignore
-      }
+  const ensureAudioCtx = () => {
+    if (audioCtxRef.current?.state === 'suspended') {
+      audioCtxRef.current.resume().catch(() => {});
     }
   };
-
-  const stopCurrentAudio = () => {
-    voicePlayTokenRef.current += 1;
-    currentVoiceUrlRef.current = '';
-
-    if (typeof window !== 'undefined' && window.speechSynthesis) {
-      window.speechSynthesis.cancel();
-    }
-
-    if (audioRafRef.current) cancelAnimationFrame(audioRafRef.current);
-    audioRafRef.current = null;
-
-    if (audioRef.current) {
-      try {
-        audioRef.current.pause();
-      } catch (_err) {
-        // no-op
-      }
-      audioRef.current = null;
-    }
-
-    threeRef.current.voiceLevel = 0;
-    threeRef.current.voiceBands = { low: 0, mid: 0, high: 0 };
-  };
-
-  const playElevenLabsVoice = (url) => {
-    if (typeof window === 'undefined' || !url) return;
-    if (currentVoiceUrlRef.current === url && audioRef.current && !audioRef.current.paused) return;
-
-    stopCurrentAudio();
-
-    const token = ++voicePlayTokenRef.current;
-    currentVoiceUrlRef.current = url;
-    lastPlayedVoiceRef.current = url;
-
-    try {
-      const audio = new Audio(url);
-      audioRef.current = audio;
-      audio.crossOrigin = 'anonymous';
-      audio.preload = 'auto';
-      audio.playsInline = true;
-
-      audio.onplay = () => {
-        if (token !== voicePlayTokenRef.current) return;
-        setCharState('speaking');
-      };
-      audio.onpause = () => {
-        if (token !== voicePlayTokenRef.current) return;
-        threeRef.current.voiceLevel = 0;
-        setCharState('idle');
-      };
-      audio.onended = () => {
-        if (token !== voicePlayTokenRef.current) return;
-        threeRef.current.voiceLevel = 0;
-        setCharState('idle');
-      };
-      audio.onerror = () => {
-        if (token !== voicePlayTokenRef.current) return;
-        threeRef.current.voiceLevel = 0;
-        setCharState('idle');
-      };
-
-      if (window.AudioContext || window.webkitAudioContext) {
-        const ctx = window.__kaoriAudioCtx || new (window.AudioContext || window.webkitAudioContext)();
-        window.__kaoriAudioCtx = ctx;
-        const analyser = ctx.createAnalyser();
-        analyser.fftSize = 128;
-        const source = ctx.createMediaElementSource(audio);
-        source.connect(analyser);
-        analyser.connect(ctx.destination);
-
-        audioAnalyserRef.current = analyser;
-        audioDataRef.current = new Uint8Array(analyser.frequencyBinCount);
-
-        const tick = () => {
-          if (token !== voicePlayTokenRef.current) return;
-          if (!audioAnalyserRef.current || !audioDataRef.current) return;
-          audioAnalyserRef.current.getByteFrequencyData(audioDataRef.current);
-
-          const bins = audioDataRef.current;
-          const n = bins.length;
-          const lowEnd = Math.max(1, Math.floor(n * 0.18));
-          const midEnd = Math.max(lowEnd + 1, Math.floor(n * 0.52));
-
-          let low = 0;
-          let mid = 0;
-          let high = 0;
-          for (let i = 0; i < n; i += 1) {
-            const v = bins[i];
-            if (i < lowEnd) low += v;
-            else if (i < midEnd) mid += v;
-            else high += v;
-          }
-
-          low /= lowEnd;
-          mid /= Math.max(1, midEnd - lowEnd);
-          high /= Math.max(1, n - midEnd);
-
-          const total = bins.reduce((sum, x) => sum + x, 0);
-          const avg = total / n;
-          threeRef.current.voiceLevel = Math.min(1, avg / 120);
-          threeRef.current.voiceBands = {
-            low: Math.min(1, low / 145),
-            mid: Math.min(1, mid / 145),
-            high: Math.min(1, high / 145),
-          };
-
-          audioRafRef.current = requestAnimationFrame(tick);
-        };
-
-        tick();
-      }
-
-      audio.play().catch(() => {
-        if (token !== voicePlayTokenRef.current) return;
-        setCharState('idle');
-      });
-    } catch (_err) {
-      if (token !== voicePlayTokenRef.current) return;
-      setCharState('idle');
-    }
-  };
-
-  const speakBrowserTTS = (_text) => {
-    // Disabled intentionally: Kaori Live should use ElevenLabs audio only.
-  };
-
-
 
   const submitText = async (text) => {
     if (!text?.trim() || !conversationId || sending || sendLockRef.current) return;
@@ -725,64 +781,15 @@ export default function KaoriLivePage() {
     setMessages((prev) => [...prev, optimistic]);
 
     try {
-      const sendStartedAt = Date.now();
-      await sendMessage(conversationId, content, token);
+      // Pass x-kith-session header so the backend fires voice through Kith
+      const extraHeaders = kithSessionRef.current
+        ? { 'x-kith-session': kithSessionRef.current }
+        : undefined;
+      await sendMessage(conversationId, content, token, extraHeaders);
 
-      // Poll briefly for the *new* Kaori reply (text + optional voice url)
-      let latestMessages = [];
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        const latest = await getMessages(conversationId, { page: 1, limit: 40 }, token);
-        latestMessages = latest?.messages || [];
-
-        const hasNewKaori = latestMessages.some((m) => {
-          const ts = new Date(m.createdAt || 0).getTime();
-          return m.senderId?.toString() !== userId?.toString() && ts >= sendStartedAt - 1000;
-        });
-
-        if (hasNewKaori) break;
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      }
-
-      setMessages(latestMessages);
-
-      const freshKaori = latestMessages
-        .filter((m) => {
-          const ts = new Date(m.createdAt || 0).getTime();
-          return m.senderId?.toString() !== userId?.toString() && ts >= sendStartedAt - 1000;
-        })
-        .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
-
-      const freshVoice = freshKaori.find((m) => extractVoiceUrl(m.content));
-      const freshVoiceUrl = extractVoiceUrl(freshVoice?.content || '');
-
-      if (freshVoiceUrl) {
-        playElevenLabsVoice(freshVoiceUrl);
-      } else {
-        // Voice message can arrive after text; keep polling briefly for ElevenLabs URL.
-        let delayedVoiceUrl = '';
-        for (let i = 0; i < 12; i += 1) {
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          const polled = await getMessages(conversationId, { page: 1, limit: 50 }, token);
-          const polledMessages = polled?.messages || [];
-          setMessages(polledMessages);
-
-          const delayedVoice = [...polledMessages]
-            .reverse()
-            .find((m) => {
-              const ts = new Date(m.createdAt || 0).getTime();
-              return m.senderId?.toString() !== userId?.toString() && ts >= sendStartedAt - 1000 && extractVoiceUrl(m.content || '');
-            });
-
-          delayedVoiceUrl = extractVoiceUrl(delayedVoice?.content || '');
-          if (delayedVoiceUrl) break;
-        }
-
-        if (delayedVoiceUrl) {
-          playElevenLabsVoice(delayedVoiceUrl);
-        } else {
-          setCharState('idle');
-        }
-      }
+      // Voice arrives via Kith WebSocket (tts_audio_chunk events).
+      // Text reply arrives via socket.io (message:new event).
+      // No polling needed.
     } catch (_error) {
       setMessages((prev) => prev.filter((m) => m._id !== optimistic._id));
       setCharState('idle');
@@ -796,14 +803,14 @@ export default function KaoriLivePage() {
   const handleSend = async (e) => {
     e.preventDefault();
     if (!input.trim()) return;
-    await unlockAudioPlayback();
+    ensureAudioCtx();
     const payload = input;
     setInput('');
     await submitText(payload);
   };
 
   const toggleVoiceInput = async () => {
-    await unlockAudioPlayback();
+    ensureAudioCtx();
     if (!SpeechRecognition) {
       alert('Voice input is not supported in this browser yet.');
       return;
@@ -900,7 +907,10 @@ export default function KaoriLivePage() {
           <div className={styles.layout}>
             <section className={styles.stagePanel}>
               <div ref={mountRef} className={styles.stage} />
-              <p className={styles.caption}>Kaori stage status: {stageDebug} · {KAORI_STAGE_BUILD_TAG} · Three.js + VRM emotes (idle/listening/thinking/speaking).</p>
+              <p className={styles.caption}>
+                Kaori stage status: {stageDebug} · {KAORI_STAGE_BUILD_TAG} · Three.js + VRM emotes
+                (idle/listening/thinking/speaking).
+              </p>
             </section>
 
             <section className={styles.chatPanel}>
@@ -910,10 +920,11 @@ export default function KaoriLivePage() {
                     msg.senderId === 'me' ||
                     (userId && msg.senderId?.toString() === userId?.toString()) ||
                     `${msg._id || ''}`.startsWith('temp-');
-                  const isVoiceLink = Boolean(extractVoiceUrl(msg.content || ''));
-                  if (isVoiceLink) return null;
                   return (
-                    <div key={msg._id || `${msg.createdAt}-${msg.content}`} className={`${styles.messageRow} ${mine ? styles.mine : styles.theirs}`}>
+                    <div
+                      key={msg._id || `${msg.createdAt}-${msg.content}`}
+                      className={`${styles.messageRow} ${mine ? styles.mine : styles.theirs}`}
+                    >
                       <div className={styles.messageBubble}>{msg.content}</div>
                     </div>
                   );
@@ -934,7 +945,16 @@ export default function KaoriLivePage() {
                   onChange={(e) => setInput(e.target.value)}
                   placeholder={listening ? 'Listening… release mic when done' : 'Talk to Kaori…'}
                 />
-                <Button type="submit" disabled={!input.trim() || sending} className={styles.sendBtn}>
+                {charState === 'speaking' && (
+                  <Button type="button" onClick={stopKithAudio} className={styles.stopBtn}>
+                    <Square size={14} />
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  disabled={!input.trim() || sending}
+                  className={styles.sendBtn}
+                >
                   {sending ? <Loader2 className={styles.spinSmall} /> : <Send size={16} />}
                 </Button>
               </form>
@@ -945,4 +965,3 @@ export default function KaoriLivePage() {
     </>
   );
 }
-

--- a/styles/kaori-live.module.css
+++ b/styles/kaori-live.module.css
@@ -128,6 +128,13 @@
   animation: pulse 1.1s ease-in-out infinite;
 }
 
+.stopBtn {
+  background: #eb5f73;
+  color: #fff;
+  min-width: 36px;
+  padding: 0 8px;
+}
+
 .sendBtn {
   background: #ffe06c;
   color: #161616;


### PR DESCRIPTION
## Summary
- Refactors `kaori-live.js` to connect to the Kith voice sidecar via WebSocket instead of polling for ElevenLabs MP3 URLs
- TTS audio arrives as streaming base64 chunks and plays through Web Audio API (gapless queue)
- Adds barge-in Stop button, `emotion_state` VRM tinting, and `x-kith-session` header on message POST
- Removes ~250 lines of polling/URL-extraction code in favor of event-driven voice delivery

## Changes
- `pages/kaori-live.js` — Kith WS connection, audio chunk queue, event handlers, Stop button
- `lib/apiMessages.js` — `sendMessage` accepts optional `extraHeaders` param
- `styles/kaori-live.module.css` — `.stopBtn` style
- `.env.example` — `NEXT_PUBLIC_KITH_VOICE_WS_URL`

## Test plan
- [ ] Start kith-voice sidecar and Backend with `KITH_VOICE_URL` set
- [ ] Open Kaori Live in browser — verify `[kith] session ready` in console
- [ ] Send a message — verify charState transitions: thinking, speaking, idle
- [ ] Verify audio plays through Web Audio (no audio element needed)
- [ ] Click Stop button during speech — verify barge-in stops audio and clears queue
- [ ] Verify emotion_state events tint VRM materials (e.g. excited = warm glow)
- [ ] Verify voice input (mic) still works end-to-end
- [ ] Verify no regressions in message display (voice-link filter removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)