### PR TITLE
docs: refresh README (architecture, badges, setup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Lint & format check
         run: |
           # Keep this extension list in sync with file types checked by Biome in this repo.
+          # This variable is documentation-only for the log message below.
           SUPPORTED_EXTENSIONS=".js, .jsx, .mjs, .cjs, .ts, .tsx, .mts, .cts, .json, .jsonc, .css"
           EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'
           mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E "$EXT_PATTERN" || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'
           mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E "$EXT_PATTERN" || true)
 
-          if [ ${#changed_files[@]} -eq 0 ]; then
+          if [ ${#changed_files[@]} -eq 0 ] || [ -z "${changed_files[0]}" ]; then
             echo "Skipping Biome check: no files matching ${EXT_PATTERN} were modified in this PR."
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,17 @@ jobs:
 
       - name: Lint & format check
         run: |
-          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E '\.(js|jsx|json|jsonc|css)$' || true)
+          # Keep this extension list in sync with file types checked by Biome in this repo.
+          SUPPORTED_EXTENSIONS=".js, .jsx, .mjs, .cjs, .ts, .tsx, .mts, .cts, .json, .jsonc, .css"
+          EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E "$EXT_PATTERN" || true)
 
           if [ ${#changed_files[@]} -eq 0 ]; then
-            echo "No Biome-supported files changed."
+            echo "Skipping Biome check: no supported files (${SUPPORTED_EXTENSIONS}) were modified in this PR."
             exit 0
           fi
 
+          echo "Running Biome on ${#changed_files[@]} changed files..."
           npx biome check "${changed_files[@]}"
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,12 @@ jobs:
 
       - name: Lint & format check
         run: |
-          # Keep this extension list in sync with file types checked by Biome in this repo.
-          # This variable is documentation-only for the log message below.
-          SUPPORTED_EXTENSIONS=".js, .jsx, .mjs, .cjs, .ts, .tsx, .mts, .cts, .json, .jsonc, .css"
+          # Keep this pattern in sync with file types checked by Biome in this repo.
           EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'
           mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E "$EXT_PATTERN" || true)
 
           if [ ${#changed_files[@]} -eq 0 ]; then
-            echo "Skipping Biome check: no supported files (${SUPPORTED_EXTENSIONS}) were modified in this PR."
+            echo "Skipping Biome check: no files matching ${EXT_PATTERN} were modified in this PR."
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint & format check
         shell: bash
         run: |
-          # Keep this pattern in sync with file types checked by Biome in this repo.
+          # Keep this pattern in sync with Biome-supported file types (see `/biome.json`).
           EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'
           mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E "$EXT_PATTERN" || true)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: npm ci
 
       - name: Lint & format check
+        shell: bash
         run: |
           # Keep this pattern in sync with file types checked by Biome in this repo.
           EXT_PATTERN='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|css)$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -22,7 +24,15 @@ jobs:
         run: npm ci
 
       - name: Lint & format check
-        run: npx biome check .
+        run: |
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -E '\.(js|jsx|json|jsonc|css)$' || true)
+
+          if [ ${#changed_files[@]} -eq 0 ]; then
+            echo "No Biome-supported files changed."
+            exit 0
+          fi
+
+          npx biome check "${changed_files[@]}"
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,112 +1,150 @@
-# The Trick Book Website
+# TrickBook Website
 
-The Trick Book is a comprehensive platform dedicated to action sports enthusiasts, providing detailed trick guides, tutorials, and community features. Built with Next.js and modern web technologies, it aims to be the go-to resource for learning and sharing action sports tricks.
+The web frontend for **TrickBook** — a social platform for action sports, by riders, for riders. Live at [thetrickbook.com](https://thetrickbook.com).
 
-## 🌟 Features
+![License: Proprietary](https://img.shields.io/badge/license-Proprietary-red)
+![Next.js](https://img.shields.io/badge/Next.js-13.5.4-black?logo=next.js&logoColor=white)
+![React](https://img.shields.io/badge/React-18.2.0-61DAFB?logo=react&logoColor=black)
+![Deployed on AWS Amplify](https://img.shields.io/badge/deployed%20on-AWS%20Amplify-FF9900?logo=awsamplify&logoColor=white)
 
-### Current Features
+## Overview
 
-- **Trickipedia**: A Wikipedia-style encyclopedia of tricks for various action sports
-  - Detailed trick descriptions and tutorials
-  - Difficulty ratings and categorization
-  - Search functionality
-  - Visual guides with images and videos
-- **Blog**: Action sports news, tips, and community stories
-  - Rich text content with image support
-  - Author attribution
-  - Responsive design
-- **User Authentication**: Secure login and registration system
-- **Admin Dashboard**: Content management system for administrators
-- **Responsive Design**: Mobile-first approach for all devices
+This is a Next.js app (**Pages Router**) that serves as both the marketing/content site and the user-facing web client for the TrickBook platform. All application data lives in the TrickBook backend API (`api.thetrickbook.com`); this app renders it, handles authentication via next-auth, and shares the same JWT auth strategy as the mobile app.
 
-### Planned Features
+Feature areas (see `pages/`):
 
-- **TrickList**: Personal trick tracking and progression system
-- **Community Features**:
-  - User profiles
-  - Trick submissions
-  - Comments and discussions
-  - Trick ratings and reviews
-- **Video Integration**: Direct video uploads and embedding
-- **Social Sharing**: Share tricks and progress on social media
-- **Mobile App**: Native mobile application for on-the-go access
+- **Blog** — ISR-rendered posts (`revalidate: 60`) fetched from the backend blog API, with SEO metadata, table of contents, and share actions.
+- **Trickipedia** — encyclopedia of tricks organized by category (`/trickipedia/[category]`).
+- **Spots** — skate spot discovery with a Google Maps view (marker clustering), browse-by-state pages, and user spot submissions.
+- **TrickBook / TrickList** — trick tracking and personal trick lists (`/trickbook/my-lists`, `/tricklist`).
+- **Messages** — real-time DMs and conversations via Socket.io.
+- **Media & profiles** — video/media feeds (Bunny CDN + HLS playback, tus resumable uploads), user profiles, homies (friends), settings.
+- **Admin dashboard** — content management for blog posts, Trickipedia entries, spots (including pending-spot moderation), categories, and analytics (`/admin`).
+- **Auth pages** — login, signup, forgot/reset password.
+- **Kaori Live** — experimental 3D VRM avatar page driven by a voice-service WebSocket (three.js + `@pixiv/three-vrm`).
 
-## 🛠️ Technology Stack
+## Architecture
 
-- **Frontend**:
-  - Next.js
-  - React
-  - Material-UI
-  - Bootstrap
-  - CSS Modules
-- **Backend**:
-  - Node.js
-  - Express
-  - MongoDB
-- **Authentication**:
-  - JWT (JSON Web Tokens)
-- **Image Handling**:
-  - Next.js Image Optimization
-  - Cloud Storage
-- **Deployment**:
-  - Vercel (Frontend)
-  - AWS/DigitalOcean (Backend)
-
-## 🚀 Getting Started
-
-1. Clone the repository
-
-```bash
-git clone https://github.com/yourusername/trickbook-website.git
+```mermaid
+flowchart TD
+    Browser[Browser] --> Next[Next.js app<br/>Pages Router, SSG/ISR]
+    Next --> AuthRoute["API route: /api/auth/[...nextauth]<br/>(next-auth v4)"]
+    AuthRoute --> Credentials[Credentials provider]
+    AuthRoute --> Google[Google provider]
+    AuthRoute --> Apple[Apple provider]
+    Credentials --> API[TrickBook Backend API<br/>api.thetrickbook.com]
+    Google --> API
+    Apple --> API
+    Next --> API
+    Next -- Socket.io --> API
+    Next -- media playback --> CDN[Bunny CDN / S3]
+    GitHub[GitHub main branch] -- amplify.yml --> Amplify[AWS Amplify<br/>build & deploy]
+    Amplify --> Next
 ```
 
-2. Install dependencies
+Key points:
+
+- The **only API route** in this app is the next-auth handler (`pages/api/auth/[...nextauth].js`). All other data access goes straight to the Express backend through the `lib/api*.js` client modules.
+- OAuth sign-ins (Google/Apple) exchange the provider token with the backend (`/api/auth/google-auth`, `/api/auth/apple-auth`), which returns the platform JWT stored on the next-auth session — the same JWT scheme the mobile app uses.
+- Blog and content pages use `getStaticProps`/`getStaticPaths` with 60-second ISR revalidation.
+
+## Tech Stack
+
+| Concern | Technology |
+|---|---|
+| Framework | Next.js 13.5 (Pages Router), React 18.2 |
+| Auth | next-auth 4.24 (Credentials, Google, Apple providers) |
+| Styling | Tailwind CSS 3.4 + MUI 5 (transitioning to Tailwind-first), Radix UI primitives, Bootstrap/react-bootstrap (legacy), next-themes for dark mode |
+| Data fetching | axios clients in `lib/` against the Express backend |
+| Real-time | socket.io-client |
+| Maps | `@vis.gl/react-google-maps` + `@googlemaps/markerclusterer` |
+| Video | Bunny Stream (HLS via hls.js, tus-js-client uploads) |
+| Payments | Stripe (`@stripe/stripe-js`) |
+| Analytics | PostHog, Google Analytics (`@next/third-parties`) |
+| 3D | three.js + `@pixiv/three-vrm` (Kaori Live) |
+| Lint/format | Biome (+ husky/lint-staged pre-commit hooks) |
+| Testing | Playwright |
+
+## Getting Started
+
+**Prerequisites:** Node 20 (see `.nvmrc`; `engines` requires `>=20`).
 
 ```bash
+nvm use                      # picks up Node 20 from .nvmrc
 npm install
+cp .env.example .env.local   # then fill in values (see below)
+npm run dev                  # http://localhost:3000
 ```
 
-3. Set up environment variables
+The app expects the TrickBook backend running locally on port 9000 (or point `NEXT_PUBLIC_BASE_URL` / `NEXT_PUBLIC_API_BASE_URL` at another environment).
+
+## Environment Variables
+
+Names and purpose only — never commit real values. `.env.local` is gitignored; **production values are managed in the AWS Amplify console** (the Amplify build writes the allow-listed vars into `.env.production` during `preBuild`).
+
+| Variable | Purpose |
+|---|---|
+| `BASE_URL` / `NEXT_PUBLIC_BASE_URL` | Backend API origin (e.g. local Express server or `https://api.thetrickbook.com`) |
+| `NEXT_PUBLIC_API_BASE_URL` | Backend API base path (`<origin>/api`) |
+| `NEXTAUTH_URL` | Canonical URL for next-auth callbacks |
+| `NEXTAUTH_SECRET` | next-auth session/JWT encryption secret |
+| `JWT_SECRET` | Shared JWT signing secret (must match backend) |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth provider |
+| `APPLE_WEB_SERVICE_ID` | Apple SSO Services ID (client ID for Sign in with Apple on web) |
+| `APPLE_TEAM_ID` / `APPLE_KEY_ID` / `APPLE_PRIVATE_KEY` | Used to mint the Apple client secret (ES256 JWT) at runtime |
+| `NEXT_PUBLIC_GOOGLE_MAPS_KEY` | Google Maps JS API key (spots map) |
+| `NEXT_PUBLIC_BUNNY_LIBRARY_ID` / `NEXT_PUBLIC_BUNNY_CDN_HOSTNAME` | Bunny Stream playback (public values) |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key |
+| `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` | PostHog analytics |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics measurement ID |
+| `NEXT_PUBLIC_KITH_VOICE_WS_URL` | Kaori voice-service WebSocket URL |
+
+See `.env.example` for the full documented template.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `npm run dev` | Start the dev server |
+| `npm run build` | Production build (`next build`) |
+| `npm start` | Serve the production build |
+| `npm run lint` / `npm run lint:fix` | Biome check (read-only / auto-fix) |
+| `npm run format` / `npm run format:check` | Biome formatting |
+| `npm run validate` | Biome check + production build (CI-style gate) |
+| `npm run test:blog-smoke` | Playwright blog smoke test |
+
+Husky + lint-staged run Biome on staged files before every commit.
+
+## Blog & Content Authoring
+
+Blog content is **API-backed, not file-backed**: posts live in the backend database and are fetched through `lib/api.js` (`https://api.thetrickbook.com/api/blog`), then statically rendered with 60-second ISR. To publish or edit a post, use the **admin dashboard** (`/admin/create-blog-post`, `/admin/blog`) as an admin user.
+
+The markdown files in `posts/` (read by `lib/posts.js` via gray-matter) are a legacy/local content path that is no longer wired into the blog pages — treat them as source-of-record drafts, not the publishing mechanism.
+
+## Testing
+
+Playwright smoke tests live in `tests/` (`playwright.config.js`):
 
 ```bash
-cp .env.example .env.local
+npm run test:blog-smoke
 ```
 
-4. Run the development server
+The config auto-boots the dev server on `127.0.0.1:3000` (reusing an existing one) and runs against Desktop Chrome. The blog smoke test asserts heading structure, image alt text, table-of-contents rendering, and visible focus styles on a live blog post.
 
-```bash
-npm run dev
-```
+## Deployment
 
-## 📝 Contributing
+- **Platform:** AWS Amplify, deploying the `main` branch to [thetrickbook.com](https://thetrickbook.com).
+- **Build spec:** `amplify.yml` — `preBuild` writes the allow-listed env vars (`NEXT_PUBLIC_*`, next-auth, Google/Apple OAuth, JWT) into `.env.production`, installs with `npm install --legacy-peer-deps --ignore-scripts`, then runs `npm run build`; artifacts are served from `.next` with `node_modules` and `.next/cache` cached between builds.
+- **Environment variables** are configured in the Amplify console per branch — never in the repo.
 
-We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
+## Related Repositories
 
-## 📄 License
+| Repo | Purpose |
+|---|---|
+| [wbaxterh/TrickBookFrontend](https://github.com/wbaxterh/TrickBookFrontend) | Mobile app (React Native / Expo) |
+| [wbaxterh/TB-Backend](https://github.com/wbaxterh/TB-Backend) | Backend API (Express, MongoDB, Socket.io) |
+| [wbaxterh/TrickBookDocs](https://github.com/wbaxterh/TrickBookDocs) | Documentation site (Docusaurus) |
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+## License
 
-## 🤝 Support
-
-For support, please:
-
-- Open an issue in the GitHub repository
-- Contact us through our website
-- Join our Discord community
-
-## 🔮 Future Vision
-
-The Trick Book aims to become the most comprehensive resource for action sports enthusiasts by:
-
-1. Expanding trick coverage across more sports
-2. Building a strong community of contributors
-3. Developing advanced features for trick progression tracking
-4. Creating a mobile app for on-the-go access
-5. Implementing AI-powered trick recognition and feedback
-
-## 📞 Contact
-
-- Website: [thetrickbook.com](https://thetrickbook.com)
-- Email: contact@thetrickbook.com
-- Twitter: [@TheTrickBook](https://twitter.com/TheTrickBook)
-- Instagram: [@thetrickbook](https://instagram.com/thetrickbook)
+Proprietary. Copyright © TrickBook. All rights reserved.


### PR DESCRIPTION
Rewrites the README to match the actual codebase:

- **Badges**: proprietary license, real Next.js/React versions, Amplify deploy
- **Architecture**: mermaid diagram of the next-auth flow (Credentials/Google/Apple → backend JWT) and Amplify pipeline
- **Setup**: Node 20 via nvm, env var table (names + purpose only, no values), scripts table
- **Corrections**: old README claimed MIT license and Vercel deployment — both wrong; blog authoring documented as API-backed via `/admin` (the `posts/` markdown path is legacy and unwired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)